### PR TITLE
Release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.jacocoverage/
 /work/
+/release/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,65 @@
-#TERSE3 by Masao Tomono is licensed under the Apache License, Version2.0
+# TERSE3
 
-note on installation
+TERSE3 by Masao Tomono is licensed under the Apache License, Version2.0
+
+## note on installation
+
 This library depends on javax.vecmath which is included in Java 3D API.
 
+
+## installation examples
+
+### for [Apache Maven](https://maven.apache.org/)
+
+``` xml
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>TERSE3-sample</artifactId>
+    <version>1.0</version>
+
+    <repositories>
+        <repository>
+            <id>TERSE3-repository</id>
+            <url>https://raw.githubusercontent.com/mtomono/TERSE3/release/release</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>mtomono</groupId>
+            <artifactId>TERSE3</artifactId>
+            <version>1.1</version>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+
+### for [Gradle](https://gradle.org/)
+
+``` groovy
+apply plugin: 'java'
+
+repositories {
+    mavenCentral()
+    maven {
+        url 'https://raw.githubusercontent.com/mtomono/TERSE3/release/release'
+    }
+}
+
+dependencies {
+    compile group: 'mtomono', name: 'TERSE3', version: '1.1'
+}
+```
+
+
+### for [sbt](https://www.scala-sbt.org/index.html)
+
+``` scala
+resolvers += "TERSE3 Repository" at "https://raw.githubusercontent.com/mtomono/TERSE3/release/release"
+
+libraryDependencies += "mtomono" % "TERSE3" % "1.1"
+```

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+
+DEBUG=1
+VECMATH_VERSION=1.5.2
+TESTNG_VERSION=6.14.3
+
+version=$1
+
+main() {
+    if [ -z "$version" ]
+    then
+        echo "Usage: ./release.sh <version>"
+        return 1
+    fi
+
+    download_release_target_jar
+    if [ $? != 0 ]; then return 1; fi
+    create_release_target_pom
+
+    local original_branch=`get_current_branch`
+    prepare_release_branch
+    push_jar_to_release_branch
+    git checkout $original_branch
+}
+
+download_release_target_jar() {
+    mkdir -p release/mtomono/TERSE3/$version
+    curl -L -o release/mtomono/TERSE3/$version/TERSE3-$version.jar https://github.com/mtomono/TERSE3/releases/download/v$version/TERSE3.jar
+}
+
+create_release_target_pom() {
+    mkdir -p release/mtomono/TERSE3/$version
+    cat <<EOF > release/mtomono/TERSE3/$version/TERSE3-$version.pom
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>mtomono</groupId>
+    <artifactId>TERSE3</artifactId>
+    <packaging>jar</packaging>
+    <version>${version}</version>
+
+    <name>TERSE3</name>
+    <url>https://github.com/mtomono/TERSE3</url>
+    <description>library for java to keep programs simple</description>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>https://raw.githubusercontent.com/mtomono/TERSE3/master/LICENSE.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Masao Tomono</name>
+        </developer>
+    </developers>
+
+    <scm>
+        <url>https://github.com/mtomono/TERSE3</url>
+        <connection>scm:git:git@github.com:mtomono/TERSE3.git</connection>
+        <developerConnection>scm:git:git@github.com:mtomono/TERSE3.git</developerConnection>
+    </scm>
+
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.vecmath</groupId>
+            <artifactId>vecmath</artifactId>
+            <version>${VECMATH_VERSION}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${TESTNG_VERSION}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+EOF
+}
+
+get_current_branch() {
+    echo $(git symbolic-ref --short HEAD)
+}
+
+prepare_release_branch() {
+    if [ -n "$(git branch | grep release)" ]
+    then
+        debug "Local release branch has aready created"
+        git checkout release
+        git pull origin release
+    else
+        git fetch origin --prune
+        if [ -n "$(git branch -r | grep origin/release)" ]
+        then
+            debug "Remote release branch has aready created"
+            git checkout -b release origin/release
+        else
+            debug "New local branch is created now"
+            git checkout --orphan release
+            git rm -rf .
+        fi
+    fi    
+}
+
+push_jar_to_release_branch() {
+    git add -f release/mtomono/TERSE3/$version/TERSE3-$version.jar
+    git add -f release/mtomono/TERSE3/$version/TERSE3-$version.pom
+
+    git commit -m "released v${version}"
+
+    git push origin release
+}
+
+debug() {
+    if [ $DEBUG ]
+    then
+        echo $1
+    fi
+}
+
+
+main


### PR DESCRIPTION
jarの依存関係を解決できるビルドツール用に、 `dist` ディレクトリの構造を maven レイアウト（ https://cwiki.apache.org/confluence/display/MAVENOLD/Repository+Layout+-+Final ）に変更しました。

以下のビルドツールで動作確認しています。

* Apache Maven: https://maven.apache.org/
* Gradle: https://gradle.org/
* sbt: https://www.scala-sbt.org/index.html


■　Apache Maven

【設定ファイル】

``` xml
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>

    <groupId>jp.example</groupId>
    <artifactId>TERSE3-sample</artifactId>
    <version>1.0</version>

    <repositories>
        <repository>
            <id>TERSE3-repository</id>
            <url>https://raw.githubusercontent.com/toshi-kawanishi/TERSE3/master/dist</url>
        </repository>
    </repositories>

    <dependencies>
        <dependency>
            <groupId>mtomono</groupId>
            <artifactId>TERSE3</artifactId>
            <version>1.0</version>
        </dependency>
    </dependencies>
</project>
```

【実行結果】

```
$ mvn dependency:tree
[INFO] Scanning for projects...
[INFO] 
[INFO] ----------------------< jp.example:TERSE3-sample >----------------------
[INFO] Building TERSE3-sample 1.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ TERSE3-sample ---
[INFO] jp.example:TERSE3-sample:jar:1.0
[INFO] \- mtomono:TERSE3:jar:1.0:compile
[INFO]    \- javax.vecmath:vecmath:jar:1.5.2:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.801 s
[INFO] Finished at: 2018-06-04T12:53:11+09:00
[INFO] ------------------------------------------------------------------------
```

■ Gradle

【設定ファイル】

``` groovy
apply plugin: 'java'

repositories {
    mavenCentral()
    maven {
        url 'https://raw.githubusercontent.com/toshi-kawanishi/TERSE3/master/dist'
    }
}

dependencies {
    compile group: 'mtomono', name: 'TERSE3', version: '1.0'
}
```

【実行結果】

```
$ gradle dependencies
Download https://repo.maven.apache.org/maven2/javax/vecmath/vecmath/1.5.2/vecmath-1.5.2.pom

> Task :dependencies 

------------------------------------------------------------
Root project
------------------------------------------------------------

apiElements - API elements for main. (n)
No dependencies

archives - Configuration for archive artifacts.
No dependencies

compile - Dependencies for source set 'main' (deprecated, use 'implementation ' instead).
\--- mtomono:TERSE3:1.0
     \--- javax.vecmath:vecmath:1.5.2

compileClasspath - Compile classpath for source set 'main'.
\--- mtomono:TERSE3:1.0
     \--- javax.vecmath:vecmath:1.5.2

compileOnly - Compile only dependencies for source set 'main'.
No dependencies

default - Configuration for default artifacts.
\--- mtomono:TERSE3:1.0
     \--- javax.vecmath:vecmath:1.5.2

implementation - Implementation only dependencies for source set 'main'. (n)
No dependencies

runtime - Runtime dependencies for source set 'main' (deprecated, use 'runtimeOnly ' instead).
\--- mtomono:TERSE3:1.0
     \--- javax.vecmath:vecmath:1.5.2

runtimeClasspath - Runtime classpath of source set 'main'.
\--- mtomono:TERSE3:1.0
     \--- javax.vecmath:vecmath:1.5.2

runtimeElements - Elements of runtime for main. (n)
No dependencies

runtimeOnly - Runtime only dependencies for source set 'main'. (n)
No dependencies

testCompile - Dependencies for source set 'test' (deprecated, use 'testImplementation ' instead).
\--- mtomono:TERSE3:1.0
     \--- javax.vecmath:vecmath:1.5.2

testCompileClasspath - Compile classpath for source set 'test'.
\--- mtomono:TERSE3:1.0
     \--- javax.vecmath:vecmath:1.5.2

testCompileOnly - Compile only dependencies for source set 'test'.
No dependencies

testImplementation - Implementation only dependencies for source set 'test'. (n)
No dependencies

testRuntime - Runtime dependencies for source set 'test' (deprecated, use 'testRuntimeOnly ' instead).
\--- mtomono:TERSE3:1.0
     \--- javax.vecmath:vecmath:1.5.2

testRuntimeClasspath - Runtime classpath of source set 'test'.
\--- mtomono:TERSE3:1.0
     \--- javax.vecmath:vecmath:1.5.2

testRuntimeOnly - Runtime only dependencies for source set 'test'. (n)
No dependencies


BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed
```

■ sbt

【設定ファイル】

``` scala
resolvers += "TERSE3 Repository" at "https://raw.githubusercontent.com/toshi-kawanishi/TERSE3/master/dist"

libraryDependencies += "mtomono" % "TERSE3" % "1.0"
```

【実行結果】

```
$ sbt dependencyTree
[info] Loading settings from plugins.sbt ...
[info] Loading project definition from /home/toshi-kawanishi/TERSE3-sample/sbt/project
[info] Loading settings from build.sbt ...
[info] Set current project to sbt (in build file:/home/toshi-kawanishi/TERSE3-sample/sbt/)
[info] default:sbt_2.12:0.1.0-SNAPSHOT [S]
[info]   +-mtomono:TERSE3:1.0
[info]     +-javax.vecmath:vecmath:1.5.2
[info]     
[success] Total time: 0 s, completed 2018/06/04 13:41:27
```
